### PR TITLE
Update parse.js

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -41,8 +41,13 @@ function parser(filePath, callback) {
             headersWithoutStatus = _.rest(splittedHeaders),
             headersArray = headersWithoutStatus.map(headerSplit),
             headers = _.zipObject(headersArray),
-            body = splittedResponse[1],
-            session;
+            session,
+            body='';
+            //the below line has been updated to cater for a response which might contain \r\n\r\n as part of the body
+            //the bug is that incomplete response is returned for the session.response
+            for(let intCounter=1; intCounter < splittedResponse.length; intCounter++){
+                body = body + splittedResponse[intCounter];
+            }
 
         if (!(sessionId in sessions)) {
             sessions[sessionId] = {


### PR DESCRIPTION
the parseContent has been updated to cater for a response which might contain \r\n\r\n as part of the body
the bug is that incomplete response is returned for the session.response... modified the code to concatenate the response body (if the body has been split due to occurrence of \r\n\r\n)